### PR TITLE
"licenses" -> "license"

### DIFF
--- a/datapackage.json
+++ b/datapackage.json
@@ -14,7 +14,7 @@
     "geodata",
     "city"
   ],
-  "licenses": {
+  "license": {
     "type": "ODC-PDDL",
     "url": "http://opendatacommons.org/licenses/pddl/1.0/"
   },


### PR DESCRIPTION
According to the data package [specification](http://specs.frictionlessdata.io/data-packages/#strongly-recommended-fields) the field for the license is `"license"`. `"licenses"` was dropped as valid field name in https://github.com/frictionlessdata/specs/pull/215
