### PR TITLE
Fix line endings: enforce LF via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.csv text eol=lf


### PR DESCRIPTION
## Summary

- Added `.gitattributes` with `*.csv text eol=lf` to prevent CRLF line endings from appearing in data files on Windows checkouts or after future regenerations.
- Data file already uses LF; no conversion needed.

## Files changed

- Added `.gitattributes` with rules:
  - `* text=auto` — enable Git's automatic text normalization
  - `*.csv text eol=lf` — force LF for all CSV files on checkout