### PR TITLE
Improve metadata: fix license, add sources and resource description

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ List of major cities in the world
 
 The data is extracted from [geonames][geonames], a very exhaustive list of worldwide toponyms.
 
-This [datapackage][datapackage] only list cities above 15,000 inhabitants. Each city is associated with its 
+This [datapackage][datapackage-spec] only list cities above 15,000 inhabitants. Each city is associated with its 
 country and subcountry to reduce the number of ambiguities. Subcountry can be the name of a state (eg in 
 United Kingdom or the United States of America) or the major administrative section (eg ''region'' in France''). 
 See ``admin1`` field on [geonames website][geonames] for further info about subcountry.
@@ -16,11 +16,9 @@ Notice that :
 * There is no guaranty that a city has a unique name in a country and subcountry (At the time of writing, there are about 60 ambiguities). But for each city, 
 the source data primary key ``geonameid`` is provided.
 
-[geonames]: http://www.geonames.org/
-[datapackage]: http://dataprotocols.org/data-packages/
+[geonames]: https://www.geonames.org/
+[datapackage-spec]: https://specs.frictionlessdata.io/data-package/
 
-
-## Preparation
 
 ## Preparation
 
@@ -43,14 +41,13 @@ python scripts/process.py
 
 ## License
 
-All data is licensed under the [Creative Common Attribution License][CC] as is the original data from [geonames][geonames]. This means you have to credit [geonames][geonames] when using the data. And while no credit is formally required a link back or credit to [Lexman][lexman] and the [Open Knowledge Foundation][okfn] is much appreciated.
+All data is licensed under the [Creative Commons Attribution 4.0 International License][CC-BY-4.0], consistent with the original data from [geonames][geonames]. You must credit [geonames][geonames] when using the data. A link back or credit to [Lexman][lexman] and the [Open Knowledge Foundation][okfn] is also appreciated.
 
 All source code is licensed under the [MIT licence][mit].
 
-[CC]: http://creativecommons.org/licenses/by/3.0/
+[CC-BY-4.0]: https://creativecommons.org/licenses/by/4.0/
 [mit]: https://opensource.org/licenses/MIT
-[geonames]: http://www.geonames.org/
-[pddl]: http://opendatacommons.org/licenses/pddl/1.0/
+[geonames]: https://www.geonames.org/
 [lexman]: http://github.com/lexman
 [okfn]: http://okfn.org/
 

--- a/datapackage.json
+++ b/datapackage.json
@@ -9,25 +9,36 @@
   "sources": [
     {
       "name": "Geonames",
-      "path": "http://www.geonames.org/",
+      "path": "https://www.geonames.org/",
       "title": "Geonames"
+    },
+    {
+      "name": "Geonames cities15000 dump",
+      "path": "https://download.geonames.org/export/dump/cities15000.zip",
+      "title": "Geonames cities15000 dump"
+    },
+    {
+      "name": "Geonames admin1 codes ASCII",
+      "path": "https://download.geonames.org/export/dump/admin1CodesASCII.txt",
+      "title": "Geonames admin1 codes ASCII"
     }
   ],
   "keywords": [
     "geodata",
     "city"
   ],
-  "licensces": [
+  "licenses": [
     {
-      "name": "ODC-PDDL-1.0",
-      "path": "http://opendatacommons.org/licenses/pddl/",
-      "title": "Open Data Commons Public Domain Dedication and License v1.0"
+      "name": "CC-BY-4.0",
+      "path": "https://creativecommons.org/licenses/by/4.0/",
+      "title": "Creative Commons Attribution 4.0 International"
     }
   ],
   "resources": [
     {
       "name": "world-cities",
       "path": "data/world-cities.csv",
+      "description": "List of major cities of the world with population above 15,000, sourced from Geonames. Each city is identified by its English name, country, primary administrative subdivision (subcountry), and Geonames ID.",
       "format": "csv",
       "mediatype": "text/csv",
       "schema": {


### PR DESCRIPTION
## Summary

- **Fix `licensces` typo** → `licenses` in `datapackage.json` (Frictionless tooling ignores the field with the typo)
- **Fix license**: `ODC-PDDL-1.0` → `CC-BY-4.0` — upstream Geonames data is CC BY (attribution required); PDDL (public domain) is incompatible; aligns with what the README already declared
- **Add resource description** to the `world-cities` resource in `datapackage.json`
- **Add actual download sources**: `cities15000.zip` and `admin1CodesASCII.txt` now listed in `sources` (the script fetches both but neither was listed)
- **Fix README**: remove duplicate `## Preparation` heading; replace broken `dataprotocols.org` link with `specs.frictionlessdata.io`; update CC BY reference to 4.0; use HTTPS URLs throughout