### PR TITLE
Add frictionless validate to CI workflow

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -34,13 +34,21 @@ jobs:
       with:
         python-version: '3.12'
 
-    - name: Install Python dependencies
+    - name: Install dependencies
       run: |
         python -m venv venv
         source venv/bin/activate
         pip install --upgrade pip
         pip install -r scripts/requirements.txt
+
+    - name: Generate data
+      run: |
+        source venv/bin/activate
         python scripts/process.py
+
+    - name: Validate data
+      run: |
+        source venv/bin/activate
         frictionless validate datapackage.json
       
     - name: Push and Commit      

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -40,7 +40,8 @@ jobs:
         source venv/bin/activate
         pip install --upgrade pip
         pip install -r scripts/requirements.txt
-        python scripts/process.py         
+        python scripts/process.py
+        frictionless validate datapackage.json
       
     - name: Push and Commit      
       env:

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,3 +1,4 @@
 requests==2.32.3
 pycountry==24.6.1
 pandas==2.2.3
+frictionless==5.18.0


### PR DESCRIPTION
## Summary

- Adds `frictionless validate datapackage.json` to the CI workflow, running after `process.py` and before the commit step
- Adds `frictionless==5.18.0` to `scripts/requirements.txt`

If the generated CSV doesn't match the declared schema (wrong columns, non-integer `geonameid`, unparseable file), the run fails before any data is committed to `main`.

Closes #13